### PR TITLE
Prefetch Projects

### DIFF
--- a/cron/cron.go
+++ b/cron/cron.go
@@ -9,6 +9,16 @@ func Run() {
 	var err error
 	c := cron.New()
 
+	_, err = c.AddFunc("@every 10s", func() {
+		err := PrefectProject()
+		if err != nil {
+			slog.Errorf("Failed to fetch projects: %v", err)
+		}
+	})
+	if err != nil {
+		slog.Errorf("Failed to run cron: %v", err)
+	}
+
 	_, err = c.AddFunc("@every 1m", func() {
 		err := UpdateProject()
 		if err != nil {

--- a/cron/project.go
+++ b/cron/project.go
@@ -9,6 +9,12 @@ import (
 	"github.com/gookit/slog"
 )
 
+func PrefectProject() (err error) {
+	_, err = srv.GetProjects("", 1, "")
+
+	return
+}
+
 func UpdateProject() (err error) {
 	c := cache.New("memory")
 

--- a/cron/project.go
+++ b/cron/project.go
@@ -20,7 +20,7 @@ func UpdateProject() (err error) {
 
 	// get all stored data in cache by key
 	for k, v := range c.Items() {
-		var cache []project.Project
+		var cacheProjects []project.Project
 		if strings.Contains(k, "projects_") {
 			projects := v.([]project.Project)
 			for _, p := range projects {
@@ -33,11 +33,11 @@ func UpdateProject() (err error) {
 						//p.Author.AvatarURL = detail.Author.AvatarURL
 					}
 				}
-				cache = append(cache, p)
+				cacheProjects = append(cacheProjects, p)
 			}
 		}
 
-		if ok, _ := c.Set(k, cache); !ok {
+		if ok, _ := c.Set(k, cacheProjects); !ok {
 			slog.Errorf("Failed to set cache for \"%s\".", k)
 		}
 	}


### PR DESCRIPTION
- Pre-fecth the project via cron every 10m to prevent fetching the project when accessed by a user.
- If (for some reason) projects are not available in the cache, the service will fetch the projects directly from the source and then store them in the cache.